### PR TITLE
fix LFS objects fetching while working with GitHub Actions

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+          lfs: true
+
+      - name: Checkout LFS objects
+        run: git lfs checkout
 
       - name: Checkout theme repo
         uses: actions/checkout@v2


### PR DESCRIPTION
猜测是由于 Git LFS 由于存在配额限制，因此在配合 GitHub Actions 使用的时候会默认使用缓存，这就导致了旧的文件 Pointer 在 Workflow 流程中没有被及时地更新。

resolve: #35 