### PR TITLE
ci(dependence): lock sphinx version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Cache key for GitHub Actions: 20210506
 
 # MegEngine dependence
-numpy
+numpy>=1.18
 opencv-python
 pyarrow
 requests
@@ -11,7 +11,7 @@ redispy
 deprecated
 
 # Sphinx and extensions
-sphinx
+sphinx==3.5.4
 sphinx-intl
 sphinxcontrib-mermaid
 sphinx-autodoc-typehints


### PR DESCRIPTION
Sphinx v4.0.0 was released but some extensions are not adapted right now.
Some deprecated APIs are removed in Sphinx v4.0.0 so it will cause error with unadapted extension.
So we need to lock the version of Sphinx util other extensions can work as expected.

Deprecated APIs: https://github.com/sphinx-doc/sphinx/blob/4.x/doc/extdev/deprecated.rst
Changelog: https://www.sphinx-doc.org/en/master/changes.html\#release-4-0-0-released-may-09-2021

Unsupported extensions: [sphinxcontrib-mermaid]