### PR TITLE
docs(dev): correct warning with the standard mermaid syntax

### DIFF
--- a/source/development/architecture-design.rst
+++ b/source/development/architecture-design.rst
@@ -126,6 +126,7 @@ Imperative Runtime 架构
 -----------------------
 
 .. mermaid::
+
     flowchart TD
 
     tensor[Tensor Wrapper]


### PR DESCRIPTION
We have added megengine architecture docs in #206 but it causes one warning message while building the doc.

https://github.com/MegEngine/Documentation/runs/3068741384?check_suite_focus=true#step:9:3070

```shell
WARNING: Error in "mermaid" directive:
maximum 1 argument(s) allowed, 2 supplied.
```

```rst
.. mermaid::
    flowchart TD

    tensor[Tensor Wrapper]
    tensor -- "创建、计算、删除" --> TI[Tensor Interpreter];
    tensor -- 记录求导关系 --> autograd
    tensor -- Trace --> tracer

    gm[Grad Manager] -- "创建 / backward" --> autograd
    autograd --> proxygraph
    autograd --> tensor
    functional -- apply --> tensor
    用户 -- "new / .numpy / del / _reset"  --> tensor

    TI -- "计算、Shape推导" --> proxygraph
    TI --> CompNode+kernel
    TI <--> DTR

    module --> functional;
    optimizer;
    quantization
```

A blank line should be inserted between the directive and contents. So I just fix it.