### PR TITLE
feat: user can specific full mode while building the documentation

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,9 +9,7 @@ github:
     addBadge: false
 
 tasks:
-  - name: Dependencies
   - init: ./scripts/bootstrap.sh
-  - name: Autobuild Sever
     command: make livehtml
         
 ports:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 # Minimal makefile for Sphinx documentation
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-MEGENGINEPY   = `python3 -c "import os; \
-                import megengine; \
-                print(os.path.dirname(megengine.__file__))"`
 LANGUAGE      ?= zh_CN
 SPHINXOPTS    ?= -j auto -D language='$(LANGUAGE)' $(AUTOBUILDOPTS)
 SPHINXBUILD   ?= sphinx-build
@@ -16,17 +13,17 @@ AUTOBUILDOPTS ?=
 help:
 	@echo "============================================== Target ======================================================"
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo " \033[36m livehtml\033[0m    to make standalone HTML files and auto re-build while detects changes"
 	@echo "============================================= Variables ===================================================="
 	@echo "Default variables in makefile:"
-	@echo "MEGENGINEPY: ${MEGENGINEPY}"
-	@echo "SOURCEDIR: ${SOURCEDIR}"
-	@echo "BUILDDIR: ${BUILDDIR}"
-	@echo "HTMLAPI: ${HTMLAPI}"
-	@echo "SPHINXOPTS: ${SPHINXOPTS}"
-	@echo "AUTOBUILDOPTS: ${AUTOBUILDOPTS}"
+	@echo "  SOURCEDIR:     ${SOURCEDIR}"
+	@echo "  BUILDDIR:      ${BUILDDIR}"
+	@echo "  HTMLAPI:       ${HTMLAPI}"
+	@echo "  SPHINXOPTS:    ${SPHINXOPTS}"
+	@echo "  AUTOBUILDOPTS: ${AUTOBUILDOPTS}"
 	@echo "=============================================== Notes ======================================================"
 	@echo "1. You can use\033[36m export PYTHONPATH=\"/path/to/megengine\"\033[0m to specify megengine python package path."
-	@echo "2. You can use\033[36m make LANGUAGE=\"[ zh_CN | en ]\" html\033[0m to specify the language displayed in documentation."
+	@echo "2. You can use\033[36m export MGE_DOC_MODE=\"MINI\"\033[0m to skip generating API Pages, which speeds up a lot."
 	@echo "For more details, please read the source code in\033[36m Makefile\033[0m."
 
 clean:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 :point_right: 你也可以选择 [成为文档贡献者](./CONTRIBUTING.md) 或者 [帮助我们进行翻译](https://crowdin.com/project/megengine)
 
+## 如何在本地构建与预览文档
 
-------
-
+参考 [这个文件](./source/development/contribute-to-docs/build-the-doc-locally.rst)
 
 ## 版权声明
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -4,11 +4,10 @@ git lfs install
 git submodule update --init --progress --depth=1 --recursive
 python3 -m pip install --user -r requirements.txt
 
-
-# TODO: Suppory for more system
+# TODO: Support for more systems and linux distributions
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install -y pandoc graphviz
 else
-    echo "Not supported for current system now."
+    echo "Not support now."
 fi
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -5,9 +5,10 @@ list see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
-# Setting for documentation editors who do not want to install megengine.
-# This will remove some pages and configurations to keep the doc slim.
-mini_doc = False
+import os
+
+mode = os.getenv("MGE_DOC_MODE", "AUTO")
+assert mode in ("AUTO", "FULL", "MINI"), 'MGE_DOC_MODE only support "AUTO" / "FULL" / "MINI"'
 
 # -- Monkey patch for `mprop` package ----------------------------------------
 # It will make some module to be a instance for getting or setting property
@@ -37,13 +38,19 @@ import logging
 # But MegEngine source code and documentation are stored in two different 
 #   repository and it's recommended to import megengine package to match.
 
-try:
+if mode == "FULL":
     import megengine
-except ImportError:
-    print("MegEngine not found. Using mini-doc mode.")
-    mini_doc = True
 else:
-    print("MegEngine found. Using standard mode.")
+    try:
+        import megengine
+    except ImportError:
+        print("MegEngine not found. Use mini mode.")
+        mode = "MINI"
+    else:
+        print("MegEngine found. Use full mode.")
+        print("MegEngine path:", os.path.dirname(megengine.__file__))
+        mode = "FULL"
+assert mode in ("MINI", "FULL")
 
 # -- Project information -----------------------------------------------------
 
@@ -95,10 +102,8 @@ exclude_patterns = [
     "**.ipynb_checkpoints",
 ]
 
-# If users do not install MegEngine in system, exclude APIs from the document.
-if mini_doc:
+if mode == "MINI":
     exclude_patterns.append("reference")
-    exclude_patterns.append("reference/api")
 
 # -- Options for internationalization ----------------------------------------
 language = "zh_CN"

--- a/source/development/contribute-to-docs/build-the-doc-locally.rst
+++ b/source/development/contribute-to-docs/build-the-doc-locally.rst
@@ -5,11 +5,25 @@
 
 除了 :ref:`doc-ci-preview` 外，在某些时候，我们需要在本地构建与预览文档。
 
-我们以 Ubuntu 18.04 + Python 3.8 环境为例，向你展示从无到有构建 MegEngine 文档的过程。
+.. warning::
+
+   文档构建有 FULL 和 MINI 两种不同的模式，可以通过配置环境变量 ``MGE_DOC_MODE`` 来决定具体的行为，
+   该环境变量提供以下三种选项：
+
+   ``AUTO`` （默认）
+     自动探测 MegEngine 包是否可用，如可用则进入 FULL 模式，否则进入 MINI 模式；
+   
+   ``MINI``
+     构建除 MegEngine API Reference 外的文档，不依赖于 MegEngine 本身，能节约大量构建时间；
+
+   ``FULL``
+     构建全部文档，包括 MegEngine API Reference, 需要设置好 MegEngine 路径。
 
 .. note::
 
-   可以选择使用 :docs:`scripts/bootstrap.sh` 脚本自动完成初始化流程。
+   可以使用 :docs:`scripts/bootstrap.sh` 脚本自动完成初始化流程，但该脚本不会自动安装 MegEngine 包。
+
+下面我们以 Ubuntu 18.04 + Python 3.8 环境为例，向你展示从无到有构建 MegEngine 文档的过程。
 
 克隆文档源码到本地
 ------------------
@@ -34,15 +48,14 @@
 
   git submodule update --init --progress --depth=1 --recursive
 
-这一步将会拉取文档所依赖的第三方子模块，比如主题（后续会进行安装）。
+这一步将会拉取文档所依赖的第三方子模块，比如主题（在后面的步骤中会进行安装）。
+
+.. _megengine-path:
 
 设置 MegEngine 路径（可选）
 ---------------------------
 
-.. warning::
-
-   如果你的本地环境并没有 MegEngine 源码，并不会影响整个文档的构建流程。
-   但在这个时候会启动 Mini-doc 模式，所有 API Reference 页面将被排除（因为它们依赖源码进行内容生成）。
+使用 FULL 模式构建文档，环境内必须要安装有 MegEngine. 
 
 根据不同的需求，有两种方式将用于构建文档的 MegEngine 导入当前 Python 环境（任选其一即可）：
 
@@ -53,9 +66,6 @@
 * 如果你是研发人员，需要在指定的 MegEngine 分支源代码上生成对应文档，则需要克隆对应分支进行编译构建。
   通过 ``export PYTHONPATH`` 的形式来临时指定特定的 MegEngine 源代码路径，
   这种方式适合开发者需要同时对源码和文档进行维护的情况。:ref:`了解如何进行从源码构建。<install>`
-
-如果你正在维护 MegEngine 的特性分支，需要添加新的 API 到文档中进行预览验证，此时一定需要使用人为编译版本。
-并且在文档的 ``source/reference/*.rst`` 将新增 API 添加到合适的位置。 
 
 安装 Sphinx 与 Pydata 主题
 --------------------------

--- a/source/development/contribute-to-docs/index.rst
+++ b/source/development/contribute-to-docs/index.rst
@@ -72,6 +72,7 @@ MegEngine 文档的贡献者大致可参考以下几个方向（由易到难）�
      有的时候，为了在本地预览自己的改动效果，我们需要学会 :ref:`how-to-build-the-doc-locally` 。
    * 你也可以根据自身情况，选择使用 `Gitpod <https://gitpod.io/#prebuild/https://github.com/MegEngine/Documentation>`_ 
      等类型的云 IDE 来创建一个临时的文档开发环境，但这需要连接到 GitHub 帐户，且会对你的网络环境有一定的要求。
+     另外由于空间限制，将不会安装 MegEngine 包，因此仅支持使用 MINI 模式来生成除 API Reference 外的文档。
 
 源码组织逻辑
 ~~~~~~~~~~~~


### PR DESCRIPTION
默认 **在用户环境中不存在  MegEngine 包时自动切换到 mini mode 从而保证运行成功** 的逻辑是不对的，现在改成了直接抛出原始 Error 并且终止程序，但提示用户可以通过启用 mini 模式来构建文档。

除了当前的写法是否可以改进以外，现在有另一个问题：bootstrap 脚本是否应该帮用户安装 MegEngine?

本来想设置更多的 mode, 比如 `skip_api`, `xxx_only` 等等，但有些过度设计的嫌疑了。

@xxr3376 @GetUpEarlier @dc3671 