### PR TITLE
chore: fix explictly MINI mode

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -40,6 +40,8 @@ import logging
 
 if mode == "FULL":
     import megengine
+elif mode == "MINI":
+    pass
 else:
     try:
         import megengine


### PR DESCRIPTION
在显示指明 MINI mode 时，之前的处理代码落入了 AUTO 的逻辑，导致无法强制 MINI mode