### PR TITLE
fix: install git-lfs and bash exit immediately while return non-zero …

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
+set -e
 
+sudo apt install git-lfs
 git lfs install
 git submodule update --init --progress --depth=1 --recursive
 python3 -m pip install --user -r requirements.txt

--- a/source/development/contribute-to-docs/build-the-doc-locally.rst
+++ b/source/development/contribute-to-docs/build-the-doc-locally.rst
@@ -33,6 +33,7 @@
 
 .. code-block:: shell
 
+   sudo apt install git-lfs
    git lfs install
    git clone https://github.com/MegEngine/Documentation
    cd Documentation


### PR DESCRIPTION
之前存在的问题：

- 没有加 ``set -e``, 脚本报错不会退出；
- 并没有实质地帮用户安装 git-lfs, 原本的指令用于安装成功后的配置。