### PR TITLE
fix(comparison): fix sliding_window/sliding_window_transpose comparis…

### DIFF
--- a/source/reference/comparison.rst
+++ b/source/reference/comparison.rst
@@ -561,10 +561,10 @@ Convolution functions
      - :py:func:`~megengine.functional.nn.deformable_conv2d`
      -
    * - :py:func:`~torch.nn.functional.unfold`
-     - :py:func:`~megengine.functional.nn.sliding_window_transpose`
+     - :py:func:`~megengine.functional.nn.sliding_window`
      -
    * - :py:func:`~torch.nn.functional.fold`
-     - :py:func:`~megengine.functional.nn.sliding_window`
+     - :py:func:`~megengine.functional.nn.sliding_window_transpose`
      -
 
 Pooling functions


### PR DESCRIPTION
pytorch  fold api 和megengine sliding window api对应写反了, 改成

unfold -> sliding window
fold -> sliding window transpose