### PR TITLE
docs: move dtr and sublinear together to recomputation

### DIFF
--- a/source/_static/images/checkpointed-backprop.gif
+++ b/source/_static/images/checkpointed-backprop.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1217679b8c61e68966c9ab4035734bedd540ceee5108c9e61c4bcea8fa59a5a
+size 312403

--- a/source/_static/images/vanilla-backprop.gif
+++ b/source/_static/images/vanilla-backprop.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48376305ae88f06459ea884c05a2674cd187761726e998e259ea5e6ef35f265f
+size 9600

--- a/source/reference/jit.rst
+++ b/source/reference/jit.rst
@@ -11,17 +11,15 @@ megengine.jit
    :toctree: api
    :nosignatures:
 
-   apply_with_tracing
-   apply_const_with_tracing
+   trace
 
+Trace Config
+------------
 .. autosummary::
    :toctree: api
    :nosignatures:
    :template: autosummary/api-class.rst
 
-   trace
-   exclude_from_trace
    SublinearMemoryConfig
-
-
-
+   DTRConfig
+   GraphOptimizationConfig

--- a/source/refs.bib
+++ b/source/refs.bib
@@ -6,3 +6,19 @@
   pages={1-84},
   doi={10.1109/IEEESTD.2019.8766229}
 }
+
+@article{chen2016training,
+  title={Training deep nets with sublinear memory cost},
+  author={Chen, Tianqi and Xu, Bing and Zhang, Chiyuan and Guestrin, Carlos},
+  journal={arXiv preprint arXiv:1604.06174},
+  year={2016}
+}
+
+@inproceedings{
+  kirisame2021dynamic,
+  title={Dynamic Tensor Rematerialization},
+  author={Marisa Kirisame and Steven Lyubomirsky and Altan Haan and Jennifer Brennan and Mike He and Jared Roesch and Tianqi Chen and Zachary Tatlock},
+  booktitle={International Conference on Learning Representations},
+  year={2021},
+  url={https://openreview.net/forum?id=Vfs_2RnOD0H}
+}

--- a/source/user-guide/index.rst
+++ b/source/user-guide/index.rst
@@ -31,7 +31,7 @@
    :hidden:
    :maxdepth: 1
 
-   model-development/dtr/index
+   model-development/recomputation.rst
    model-development/distributed/index
    model-development/quantization/index
    model-development/amp/index
@@ -106,8 +106,7 @@ MegEngine Cookbook
 
 .. dropdown:: :fa:`eye,mr-1` 如何在使用 MegEngine 训练模型时节省显存？
 
-   * 你可以选择开启动态图 Sublinear 显存优化，参考 :ref:`dtr-guide`.
-   * 在使用 :ref:`jit-guide` 时，也可以开启静态图 Sublinear 显存优化，参考 TBD.
+   请参考 :ref:`recomputation-guide` 。
 
 .. dropdown:: :fa:`eye,mr-1` 如何在使用调试、优化、验证模型的性能？
 
@@ -117,10 +116,8 @@ MegEngine Cookbook
 
 .. dropdown:: :fa:`eye,mr-1` 如何对 MegEngine 的功能进行拓展？
 
-   * 如果你希望为 MegEngine 添加新的算子，请参考 TBD.
-   * 如果你希望为 MegEngine 添加新的 Optimizer, 请参考 TBD.
-   * 如果你希望优化 MegEngine 中的 Kernel, 请参考 TBD.
-   * 如果你希望参与到 MegEngine 的开发中来，请参考 :ref:`development`.
+   * 如果你希望为 MegEngine 添加新的算子，请参考 :ref:`add-an-operator` 。
+   * 如果你希望参与到 MegEngine 的开发中来，请参考 :ref:`development`  
 
 寻求更多支持
 ------------

--- a/source/user-guide/model-development/dtr/index.rst
+++ b/source/user-guide/model-development/dtr/index.rst
@@ -1,129 +1,68 @@
 .. _dtr-guide:
 
 ================================
-动态图 Sublinear 显存优化（DTR）
+使用 DTR 进行显存优化
 ================================
 
-MegEngine 通过引入 `Dynamic Tensor Rematerialization <https://arxiv.org/pdf/2006.09616.pdf>`_
-（简称 DTR）技术，进一步工程化地解决了动态图显存优化的问题，从而享受到大 Batchsize 训练带来的收益。
+MegEngine 通过引入 `DTR <https://arxiv.org/pdf/2006.09616.pdf>`_ :footcite:p:`kirisame2021dynamic` 技术来进行动态图下的显存优化，同时也支持在静态图下开启。 
 
+.. footbibliography::
 
-单卡训练
---------
+DTR 使用与配置方式
+---------------------
 
-使用方式十分简单，在训练代码之前添加两行代码：
+在训练代码之前添加一行代码，即可启用动态图的 DTR 显存优化：
+
+>>> megengine.dtr.enable()
+
+.. versionadded:: 1.5
+   用户现在可以直接开启 DTR 优化，不再需要设置一个显存阈值  :py:data:`~.dtr.eviction_threshold` 作为触发条件。
+   MegEngine 默认会在当前空闲的显存无法满足一次申请时尝试进行优化，根据 DTR 策略找出最优的 Tensor 并释放其显存，直到该次显存申请成功。
+
+   而在 1.4 版本中，必须提前设置好显存阈值，才能开启 DTR 显存优化：
+
+   >>> megengine.dtr.eviction_threshold = "5GB"
+   >>> megengine.dtr.enable()
+   
+.. admonition:: 显存阈值的设置技巧
+   :class: note
+
+   一般情况下，显存阈值设得越小，显存峰值就越低，训练耗时也会越大；显存阈值设得越大，显存峰值就越高，训练耗时也会越小。
+   但值得注意的是，当显存阈值接近显卡容量时，容易引发碎片问题。因为 DTR 是根据活跃的显存大小来执行释放操作的，释放掉的 Tensor 在显卡上的物理地址很可能不连续。
+   例如：释放了两个物理位置不相邻的 100MB 的 Tensor, 仍然无法满足一次 200MB 显存的申请。此时就会自动触发碎片整理操作，对性能造成巨大影响。
+
+.. admonition:: 结合分布式训练
+   :class: note
+
+   在分布式情景下，我们通常会使用 :class:`~.distributed.launcher` 将一个函数包装成一个多进程运行的函数，
+   此时如果想要开启 DTR 显存优化，需要在被包装的函数中定义 DTR 的参数：
+
+   .. code-block:: python
+
+      @dist.launcher
+      def main():
+
+          megengine.dtr.enable()
+
+   如果你还不清楚相关概念，可参考 :ref:`distributed-guide` 页面了解细节。
+
+.. seealso::
+
+   还有一些其它的接口如 :py:data:`~.dtr.evictee_minimum_size`, :py:data:`~.dtr.enable_sqrt_sampling` ...
+   可以对 DTR 策略进行自定义，更多配置说明请参考 :py:mod:`~.dtr` 模块的 API 文档页面。
+
+在静态图下开启 DTR
+-------------------
+
+用户在编译静态图时使用 :class:`~.jit.DTRConfig` 设置 :class:`~.jit.trace` 的参数 ``dtr_config``, 就可以打开 DTR 优化：
 
 .. code-block:: python
 
-   import megengine as mge
+   from megengine.jit import trace, DTRConfig
 
-   mge.dtr.eviction_threshold = "5GB" # set the eviction threshold to 5 GB
-   mge.dtr.enable()                   # enable the DTR optimization
+   config = DTRConfig(eviction_threshold=8*1024**3)
 
-   # ... your training code
-
-即可启用动态图的 Sublinear 显存优化。
-
-.. note::
-
-   从 MegEngine V1.5 开始，在开启 DTR 优化时不设置 ``eviction_threshold`` 也是被允许的。此时动态图显存优化将会在空闲的显存无法满足一次申请时生效，根据 DTR 的策略找出最优的 tensor 并释放其显存，直到该次显存申请成功。
-
-分布式训练
-----------
-
-关于分布式训练的开启，请参考 :ref:`分布式训练 <distributed-guide>` 。
-
-:class:`~.distributed.launcher` 将一个 function 包装成一个多进程运行的 function，你需要在这个 function 中定义 DTR 的参数：
-
-.. code-block:: python
-
-   import megengine as mge
-   import megengine.distributed as dist
-
-   @dist.launcher
-   def main():
-
-       mge.dtr.eviction_threshold = "5GB" # set the eviction threshold to 5 GB
-       mge.dtr.enable()                   # enable the DTR optimization
-
-       # ... your training code
-
-更多设置
---------
-
-参数介绍
-~~~~~~~~~
-
-.. list-table::
-    :widths: 20 40
-    :header-rows: 1
-
-    * - 参数名
-      - 实际含义
-    * - ``eviction_threshold``
-      - 显存阈值（单位：字节）。当被使用的显存总和超过该阈值后，显存优化会生效，根据 DTR 的策略找出最优的 tensor 并释放其显存，直到被使用的显存总和低于该阈值。默认值：0
-    * - ``evictee_minimum_size``
-      - 被释放显存的 tensor 的大小下限（单位：字节）。只有当 tensor 的大小不小于该下限时，才有可能被 DTR 策略选中释放其显存。默认值：1048576
-    * - ``enable_sqrt_sampling``
-      - 是否开启根号采样。设当前候选 tensor 集合的大小为 :math:`n`，开启该设置后，每次需要释放 tensor 时只会遍历 :math:`\sqrt{n}` 个候选 tensor。默认值：False
-
-设置方法请参考 :py:mod:`~.dtr`
-
-显存阈值的设置技巧
-~~~~~~~~~~~~~~~~~~
-
-``eviction_threshold`` 表示开始释放 tensor 的显存阈值。当被使用的显存大小超过该阈值时，动态图显存优化会生效，
-根据 DTR 的策略找出最优的 tensor 并释放其显存，直到活跃的显存大小不超过该阈值。因此实际运行时的活跃显存峰值比该阈值高一些属于正常现象。
-
-一般情况下，显存阈值设得越小，显存峰值就越低，训练耗时也会越大；显存阈值设得越大，显存峰值就越高，训练耗时也会越小。
-
-值得注意的是，当显存阈值接近显卡容量时，容易引发碎片问题。因为 DTR 是根据活跃的显存大小来执行释放操作的，释放掉的 tensor 在显卡上的物理地址很可能不连续。
-例如：释放了两个物理位置不相邻的 100MB 的 tensor，仍然无法满足一次 200MB 显存的申请。此时就会自动触发碎片整理操作，对性能造成巨大影响。
-
-下图是 ResNet50（batch size=200）在2080Ti（显存：11GB）上设定不同显存阈值后的性能表现。
-
-.. image:: ../../../_static/images/resnet50_wrt_mb.png
-   :align: center
-
-性能表现
-''''''''
-
-如上图（左）所示，
-
-* 当显存阈值从 2 增长到 7 的时候，训练耗时是越来越低的，因为随着显存阈值升高，释放掉的 tensor 数量变少，重计算的开销降低；
-* 当显存阈值增长到 8 和 9 的时候，可供申请的空闲显存总和已经不多，并且地址大概率不连续，导致需要不断地进行碎片整理，造成训练耗时显著增长，
-* 当显存阈值增长到 10 之后，空闲的显存甚至无法支持一次 kernel 的计算，导致 OOM.
-
-显存峰值
-''''''''
-
-如上图（右）所示，可以看出显存阈值和显存峰值之间有很大的差距。
-
-* 当显存阈值在 2 到 5 之间时，显存峰值都在 8 左右；
-* 当显存阈值在 6 到 9 之间时，显存峰值更是逼近显存总容量。
-
-前者的原因是，DTR 只能保证在任意时刻，被使用的显存总和在显存阈值附近，但是这些被使用的显存的地址不一定连续。
-被释放掉的空闲块会被 MegEngine 收集起来，当最大的空闲块大小也满足不了一次申请时, MegEngine 会从 CUDA 申请一段新的显存，
-虽然被使用的显存总量在显存阈值附近，但是显存峰值上升了；
-后者的原因是显存容量总共只有 11G，如果最大的空闲块大小也无法满足申请时只能靠碎片整理来满足申请，峰值不会变得更大。
-
-所以从 ``nvidia-smi`` 上看到的显存峰值会显著高于显存阈值。
-
-综上所述，在实际训练过程中，显存阈值需要用户根据模型和显卡的具体情况设定。
-
-FAQ
----
-
-Q：为什么 ``eviction_threshold=2GB`` 的时候训练耗时远高于 ``eviction_threshold=3GB`` 的训练耗时？
-
-A：因为在该模型中，不可被释放的 tensor（例如：参数、执行当前算子需要用到的输入 tensor 和产生的输出 tensor 等等）的大小之和一直保持在 2GB 以上，所以几乎所有的 tensor 都会在不被用到的时刻立即被释放，所以会产生非常可观的重计算时间开销。
-
-Q：为什么 ``eviction_threshold=2GB`` 的时候显存峰值高于 ``eviction_threshold=3GB`` 的显存峰值？
-
-A：原因同上，由于 ``eviction_threshold=2GB`` 时重计算次数远多于 ``eviction_threshold=3GB`` ，需要频繁地申请和释放显存，
-一旦某次空闲块大小不能满足申请，显存峰值就会增加，所以 ``eviction_threshold=2GB`` 时显存峰值大概率更高。
-
-Q：用不同的 ``eviction_threshold`` 训练模型时的显存峰值可以估算吗？
-
-A：很难。这取决于 DTR 策略释放和重计算了哪些 tensor，以及具体到某次显存申请时空闲块大小能否满足要求，这些都会影响最终的显存峰值。
+   @trace(symbolic=True, dtr_config=config)
+   def train_func(data, label, * , net, optimizer, gm):
+       ...
 

--- a/source/user-guide/model-development/jit/trace.rst
+++ b/source/user-guide/model-development/jit/trace.rst
@@ -178,52 +178,6 @@ MegEngine 在编译静态图时有 “动态构造” 和 “静态构造” 两
    如果想要使用 :py:meth:`~.jit.trace.dump` 导出模型序列化文件并进行后续处理，
    则必须在 :py:class:`~.jit.trace` 时固定参数。
 
-.. _sublinear-memory:
-
-亚线性内（显）存优化
-~~~~~~~~~~~~~~~~~~~~
-
-
-亚线性内存优化技术的直观好处是能节省显存，换来更大的 Batch size, 
-但在编译计算图和训练模型时有少量的额外时间开销（以时间换空间）。
-MegEngine 提供了两种具体的亚线性内存优化的算法，分别是 `Sublinear <https://arxiv.org/abs/1604.06174>`_ 和 `DTR <https://arxiv.org/abs/2006.09616>`_ 算法。它们的基本原理都是通过事先搜索最优的计算图节点作为前向传播和反向传播检查点（checkpoints），
-省去其它中间结果存储。
-
-用户在编译静态图时使用 :class:`~.jit.SublinearMemoryConfig` 设置 :class:`~.jit.trace` 
-的参数 ``sublinear_memory_config`` ，就可以打开 Sublinear 优化：
-
-.. code-block:: python
-
-   from megengine.jit import trace, SublinearMemoryConfig
-
-   config = SublinearMemoryConfig()
-
-   @trace(symbolic=True, sublinear_memory_config=config)
-   def train_func(data, label, * , net, optimizer, gm):
-        ...
-
-用户在编译静态图时使用 :class:`~.jit.DTRConfig` 设置 :class:`~.jit.trace` 
-的参数 ``dtr_config`` ，就可以打开 DTR 优化：
-
-.. code-block:: python
-
-   from megengine.jit import trace, DTRConfig
-
-   config = DTRConfig(eviction_threshold=8*1024**3)
-
-   @trace(symbolic=True, dtr_config=config)
-   def train_func(data, label, * , net, optimizer, gm):
-        ...
-
-.. note::
-
-   关于 ``eviction_threshold`` 的含义与设置，请参考 :ref:`动态图 Sublinear 显存优化 <dtr-guide>`
-
-经过测试，在 2080Ti GPU （显存容量为 11GB 左右）训练 ResNet50 模型，
-不使用亚线性内存优化，可用的 ``batch_size`` 最大为 100 左右；
-使用 Sublinear 优化，可用的 ``batch_size`` 最大为 300 左右；
-使用 DTR 优化，可用的 ``batch_size`` 最大为 450 左右，效果十分明显。
-
 .. _codegen:
 
 减少访存操作实现加速

--- a/source/user-guide/model-development/recomputation.rst
+++ b/source/user-guide/model-development/recomputation.rst
@@ -1,0 +1,35 @@
+.. _recomputation-guide:
+
+=========================================
+通过重计算节省显存（Recomputation）
+=========================================
+
+通常而言，使用更大的模型和更大的 Batch size 可以取得更好的训练效果，但随之而来的是更大的显存占用。
+
+重计算（Recomputation）本质上是一种用时间换空间的策略，可以将它类比成一种 Tensor 缓存（Cache）策略，
+当显存空间不足时，可以选择把一些前向计算的结果清除；
+当需要再次用到这些计算结果时，再根据之前缓存的检查点（Checkpoint）去重新计算它们。
+参考下面这个示意图，蓝色为占用的显存（ `图片来源 <https://www.zhihu.com/question/274635237/answer/755102181>`_ ）： 
+
+.. panels::
+   :container: +full-width text-center
+   :card:
+
+   Vanilla backprop
+   ^^^^^^^^^^^^^^^^
+   .. figure:: ../../_static/images/vanilla-backprop.gif
+      :align: center
+
+   ---
+   Checkpointed backprop
+   ^^^^^^^^^^^^^^^^^^^^^
+   .. figure:: ../../_static/images/checkpointed-backprop.gif
+      :align: center
+
+MegEngine 将经典的重计算策略应用到了工程实现中，具体使用方式请参考以下页面：
+
+.. toctree::
+   :maxdepth: 1
+
+   dtr/index
+   sublinear/index

--- a/source/user-guide/model-development/sublinear/index.rst
+++ b/source/user-guide/model-development/sublinear/index.rst
@@ -1,0 +1,27 @@
+.. _sublinear-guide:
+
+==================================
+使用 Sublinear 进行显存优化
+==================================
+
+.. warning::
+
+   Sublinear 仅支持在静态图模式下开启，参考 :ref:`convert-dynamic-graph-to-static` 。
+
+MegEngine 通过引入 `Sublinear <https://arxiv.org/pdf/2006.09616.pdf>`_ :footcite:p:`chen2016training` 技术来进行静态图下的显存优化。 
+
+.. footbibliography::
+
+用户在编译静态图时使用 :class:`~.jit.SublinearMemoryConfig` 设置 :class:`~.jit.trace` 
+的参数 ``sublinear_memory_config``, 就可以打开 Sublinear 优化：
+
+.. code-block:: python
+
+   from megengine.jit import trace, SublinearMemoryConfig
+
+   config = SublinearMemoryConfig()
+
+   @trace(symbolic=True, sublinear_memory_config=config)
+   def train_func(data, label, * , net, optimizer, gm):
+        ...
+


### PR DESCRIPTION
将用于动态图的 DTR 和用于静态图的 Subliear 合并到重计算页面下，以进行显式的区分。