### PR TITLE
添加 MegEngine 推理教程简介与 FastAPI Demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ datasets/
 # MegEngine files
 *.mge
 *.pkl
+output/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/examples/deploy/fastapi/data.py
+++ b/examples/deploy/fastapi/data.py
@@ -1,0 +1,34 @@
+import megengine.data as data
+import megengine.data.transform as T
+
+from megengine.data.dataset import MNIST
+
+
+def build_dataset(path, batch_size=64):
+    """Build train and test dataloader from MNIST dataset."""
+
+    transform = T.Compose([
+        T.Normalize(0.1307*255, 0.3081*255),
+        T.Pad(2),
+        T.ToMode("CHW"),
+    ])
+
+    train_dataset = MNIST(path, train=True)
+    train_sampler = data.RandomSampler(
+        train_dataset, batch_size=batch_size)
+    train_dataloader = data.DataLoader(
+        train_dataset,
+        sampler=train_sampler,
+        transform=transform,
+    )
+
+    test_dataset = MNIST(path, train=False)
+    test_sampler = data.SequentialSampler(
+        test_dataset, batch_size=batch_size)
+    test_dataloader = data.DataLoader(
+        test_dataset,
+        sampler=test_sampler,
+        transform=transform,
+    )
+
+    return train_dataloader, test_dataloader

--- a/examples/deploy/fastapi/inference.py
+++ b/examples/deploy/fastapi/inference.py
@@ -1,0 +1,59 @@
+import sys
+import argparse
+
+import cv2
+import numpy as np
+
+import megengine as mge
+import megengine.functional as F
+
+from model import LeNet
+
+logging = mge.logger.get_logger()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Infer an input handwritten image with trained model.")
+    parser.add_argument("-m", "--model", default=None, type=str)
+    parser.add_argument("-i", "--image", default=None, type=str)
+    args = parser.parse_args()
+
+    model = LeNet()
+    if args.model is not None:
+        logging.info("load from checkpoint %s", args.model)
+        checkpoint = mge.load(args.model)
+        if "state_dict" in checkpoint:
+            state_dict = checkpoint["state_dict"]
+        model.load_state_dict(state_dict)
+
+    if args.image is None:
+        path = sys.path[0] + \
+            "/../../../source/_static/images/handwrittern-digit.png"
+        logging.info("Input image was not given, use the default example.")
+    else:
+        path = args.image
+
+    image = cv2.imread(path, cv2.IMREAD_COLOR)
+    processed_img = process(image)
+    processed_img = mge.Tensor(processed_img).reshape((1, 1, 32, 32))
+
+    def infer_func(processed_img):
+        logit = model(processed_img)
+        label = F.argmax(logit).item()
+        return label
+
+    label = infer_func(processed_img)
+
+    print(f"The predicted class is {label}.")
+
+
+def process(image):
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    image = cv2.resize(image, (32, 32))
+    image = np.array(255 - image)
+    return image
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/deploy/fastapi/model.py
+++ b/examples/deploy/fastapi/model.py
@@ -1,0 +1,28 @@
+import megengine as mge
+import megengine.functional as F
+import megengine.module as M
+
+__all__ = ["LeNet"]
+
+
+class LeNet(M.Module):
+    def __init__(self, num_classes: int = 10) -> None:
+        super().__init__()
+        self.conv1 = M.Conv2d(1, 6, 5)
+        self.conv2 = M.Conv2d(6, 16, 5)
+        self.fc1 = M.Linear(16 * 5 * 5, 120)
+        self.fc2 = M.Linear(120, 84)
+        self.classifier = M.Linear(84, 10)
+
+        self.relu = M.ReLU()
+        self.pool = M.MaxPool2d(2, 2)
+
+    def forward(self, x):
+        x = self.pool(self.relu(self.conv1(x)))
+        x = self.pool(self.relu(self.conv2(x)))
+        x = F.flatten(x, 1)
+        x = self.relu(self.fc1(x))
+        x = self.relu(self.fc2(x))
+        x = self.classifier(x)
+        return x
+

--- a/examples/deploy/fastapi/server.py
+++ b/examples/deploy/fastapi/server.py
@@ -1,0 +1,60 @@
+import cv2
+import io
+import uvicorn
+import numpy as np
+
+import megengine as mge
+import megengine.functional as F
+from fastapi import FastAPI, UploadFile, File, HTTPException
+
+from model import LeNet
+
+checkpoint_path = "output/checkpoint.pkl"
+checkpoint = mge.load(checkpoint_path)
+if "state_dict" in checkpoint:
+    state_dict = checkpoint["state_dict"]
+
+model = LeNet()
+model.load_state_dict(state_dict)
+
+app = FastAPI(title="Deploying a MegEngine LeNet Model with FastAPI")
+
+
+@app.get("/")
+def home():
+    return "The server is woking~ Now head over to http://localhost:8000/docs"
+
+
+@app.post("/predict")
+async def prediction(file: UploadFile = File(...)):
+
+    filename = file.filename
+    fileExtension = filename.split(".")[-1] in ("jpg", "jpeg", "png")
+    if not fileExtension:
+        raise HTTPException(
+            status_code=415, detail="Unsupported file provided.")
+    if file.content_type.startswith('image/') is False:
+        raise HTTPException(
+            status_code=400, detail="File is not an image."
+        )
+
+    contents = await file.read()
+    image_stream = io.BytesIO(contents)
+    image_stream.seek(0)
+    file_bytes = np.asarray(bytearray(image_stream.read()))
+    image = cv2.imdecode(file_bytes, cv2.IMREAD_COLOR)
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    image = cv2.resize(image, (32, 32))
+    image = np.array(255 - image)
+    image = mge.Tensor(image).reshape((1, 1, 32, 32))
+
+    logit = model(image)
+    label = F.argmax(logit).item()
+
+    return {
+        "filename": file.filename,
+        "contenttype": file.content_type,
+        "likely_class": label,
+    }
+
+uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/examples/deploy/fastapi/test.py
+++ b/examples/deploy/fastapi/test.py
@@ -1,0 +1,65 @@
+import argparse
+
+import megengine as mge
+import megengine.functional as F
+
+from data import build_dataset
+from model import LeNet
+
+logging = mge.logger.get_logger()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test MegEngine LeNet Model on MNIST dataset")
+    parser.add_argument("-d", "--data", help="path to MNIST dataset")
+    parser.add_argument(
+        "-m", "--model",
+        metavar="PKL",
+        default=None,
+        help="path to model checkpoint"
+    )
+
+    args = parser.parse_args()
+
+    # Build dataset
+    _, test_dataloader = build_dataset(args.data)
+
+    # Build model and load from checkpoint
+    model = LeNet()
+    if args.model is not None:
+        logging.info("load from checkpoint %s", args.model)
+        checkpoint = mge.load(args.model)
+        if "state_dict" in checkpoint:
+            state_dict = checkpoint["state_dict"]
+        model.load_state_dict(state_dict)
+
+    # Valid function
+    def valid_step(image, label):
+        logits = model(image)
+        loss = F.nn.cross_entropy(logits, label)
+        pred = F.argmax(logits, axis=1)
+        correct = (pred == label).sum().item()
+        return loss, correct
+
+    model.eval()
+    total_loss, total_num, correct_num = 0, 0, 0
+    for image, label in test_dataloader:
+        image = mge.Tensor(image)
+        label = mge.Tensor(label)
+        loss, correct = valid_step(image, label)
+        total_loss += loss.item()
+        correct_num += correct
+        total_num += len(label)
+    valid_loss = float(total_loss)/total_num
+    valid_acc = float(correct_num)/total_num
+
+    # Save logging information
+    logging.info("Valid loss: %.6f valid acc %.6f",
+                 valid_loss,
+                 valid_acc,
+                 )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/deploy/fastapi/train.py
+++ b/examples/deploy/fastapi/train.py
@@ -1,0 +1,150 @@
+import argparse
+import os
+
+import megengine as mge
+import megengine.autodiff as autodiff
+import megengine.optimizer as optim
+import megengine.functional as F
+
+from data import build_dataset
+from model import LeNet
+
+logging = mge.logger.get_logger()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Train MegEngine LeNet Model on MNIST dataset")
+    parser.add_argument("-d", "--data", help="path to MNIST dataset")
+    parser.add_argument(
+        "--save",
+        metavar="DIR",
+        default="output",
+        help="path to save checkpoint and log",
+    )
+    parser.add_argument(
+        "--epochs",
+        default=30,
+        type=int,
+        help="number of total epochs to run (default: 90)",
+    )
+    parser.add_argument(
+        "-b",
+        "--batch-size",
+        metavar="SIZE",
+        default=64,
+        type=int,
+        help="batch size for single GPU (default: 64)")
+
+    parser.add_argument(
+        "--lr",
+        "--learning-rate",
+        metavar="LR",
+        default=0.025,
+        type=float,
+        help="learning rate for single GPU (default: 0.025)",
+    )
+    parser.add_argument(
+        "--momentum",
+        default=0.9,
+        type=float,
+        help="momentum (default: 0.9)"
+    )
+    parser.add_argument(
+        "--weight-decay",
+        default=1e-4,
+        type=float,
+        help="weight decay (default: 1e-4)"
+    )
+
+    args = parser.parse_args()
+
+    # Logging config
+    os.makedirs(args.save, exist_ok=True)
+    mge.logger.set_log_file(os.path.join(args.save, "log.txt"))
+
+    # Build dataset
+    train_dataloader, test_dataloader = build_dataset(
+        args.data, args.batch_size)
+
+    # Build model
+    model = LeNet()
+
+    # Autodiff gradient manager
+    gm = autodiff.GradManager().attach(
+        model.parameters(),
+    )
+
+    # Optimizer
+    opt = optim.SGD(
+        model.parameters(),
+        lr=args.lr,
+        momentum=args.momentum,
+        weight_decay=args.weight_decay,
+    )
+
+    # Train and valid function
+    def train_step(image, label):
+        with gm:
+            logits = model(image)
+            loss = F.nn.cross_entropy(logits, label)
+            gm.backward(loss)
+            opt.step().clear_grad()
+        pred = F.argmax(logits, axis=1)
+        correct = (pred == label).sum().item()
+        return loss, correct
+
+    def valid_step(image, label):
+        logits = model(image)
+        loss = F.nn.cross_entropy(logits, label)
+        pred = F.argmax(logits, axis=1)
+        correct = (pred == label).sum().item()
+        return loss, correct
+
+    # Start training and validation in each epoch
+    for epoch in range(args.epochs):
+
+        model.train()
+        total_loss, total_num, correct_num = 0, 0, 0
+        for image, label in train_dataloader:
+            image = mge.Tensor(image)
+            label = mge.Tensor(label)
+            loss, correct = train_step(image, label)
+            total_loss += loss.item()
+            correct_num += correct
+            total_num += len(label)
+        train_loss = float(total_loss)/total_num
+        train_acc = float(correct_num)/total_num
+
+        model.eval()
+        total_loss, total_num, correct_num = 0, 0, 0
+        for image, label in test_dataloader:
+            image = mge.Tensor(image)
+            label = mge.Tensor(label)
+            loss, correct = valid_step(image, label)
+            total_loss += loss.item()
+            correct_num += correct
+            total_num += len(label)
+        valid_loss = float(total_loss)/total_num
+        valid_acc = float(correct_num)/total_num
+
+        # Save logging information
+        logging.info("Epoch: %02d train loss: %.6f train acc: %.6f valid loss: %.6f valid acc %.6f",
+                     epoch,
+                     train_loss,
+                     train_acc,
+                     valid_loss,
+                     valid_acc,
+                     )
+
+        # Save checkpoint every 10 epochs
+        if (epoch + 1) % 10 == 0:
+            mge.save({
+                "epoch": epoch + 1,
+                "state_dict": model.state_dict(),
+            },
+                os.path.join(args.save, "checkpoint.pkl"))
+
+
+if __name__ == "__main__":
+    main()

--- a/source/_static/images/fastapi.png
+++ b/source/_static/images/fastapi.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ab71030ae37bd07aea5b2306cd98360e27ce3fd2369fe9ef230109b68fe87bd
+size 26880

--- a/source/_static/images/ml-iteration.png
+++ b/source/_static/images/ml-iteration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f56ba276554ce3f6b43c4eccc5ebab622640dc63cb9cac37d8178436a399a16d
+size 69203

--- a/source/_static/images/real-world-ml-system.png
+++ b/source/_static/images/real-world-ml-system.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ac22027a3d99a920a2403c8c36a3eb8da9b33e0e69f0f56a199471ca3ac99e2
+size 51408

--- a/source/getting-started/deploy/fast-api.rst
+++ b/source/getting-started/deploy/fast-api.rst
@@ -1,0 +1,246 @@
+.. _deploy-fastapi:
+
+====================================
+使用 FastAPI 快速部署 MegEngine 模型
+====================================
+.. admonition:: 本教程涉及的内容
+   :class: note
+
+   * 快速回顾 MegEngine 模型开发的基本流程，了解如何加载训练好的模型；
+   * 学习 FastAPI 的基本使用，理解服务端和客户端等相关概念；
+   * 将训练好的 MNIST 模型在本地进行服务部署，并进行推理验证。
+
+.. seealso::
+
+   * 本教程所用到的源码： :docs:`examples/deploy/fastapi` （可与 :ref:`megengine-quick-start` 代码对比）
+   * 需要阅读 `FastAPI <https://fastapi.tiangolo.com/>`_ 官网文档并在你的环境中安装好该框架。
+     
+.. admonition:: 这不是 MegEngine 模型推理的最佳实践！
+   :class: warning
+
+   本篇教程的内容仅仅是为了帮助概念入门，实际生产环境中通常不会用到这样的部署模式。
+
+快速回顾：模型开发步骤
+----------------------
+
+.. dropdown:: :fa:`eye,mr-1` 查看 MNIST 数据集介绍
+
+   `MNIST <http://yann.lecun.com/exdb/mnist/>`_ :footcite:p:`lecun2010mnist`
+   手写数字数据集中包含 60,000 张训练图像和 10,000 张测试图像，每张图片是 28x28 像素的灰度图。
+   如今 MNIST 已然成为机器学习领域的 “Hello, world!”, 用来验证框架和库的可用性。
+
+   .. figure:: ../../_static/images/MnistExamples.png
+
+      By `Josef Steppan - Own work <https://commons.wikimedia.org/w/index.php?curid=64810040>`_ , CC BY-SA 4.0
+
+你可以选择 Clone 文档获得源码，或者手动进行下载：
+
+.. code-block:: shell
+
+   git clone git@github.com:MegEngine/Documentation.git --depth=1
+   cd Documentation
+
+接下来的步骤在快速上手以及入门教程中都有介绍过（不关注这些步骤的读者只需运行代码即可）：
+
+#. 训练 MNIST 手写数字分类模型（推荐使用 GPU 环境， ``--help`` 查看帮助信息）：
+
+   .. code-block:: shell
+
+      python3 examples/deploy/fastapi/train.py --data /path/to/MNIST
+
+   默认总共训练 30 epochs, 每 10 epochs 保存一次检查点，训练同时记录日志信息。
+
+   你应当可以看到模型精度在 99% 以上，并且在 ``fastapi/output`` 目录下有文件生成。
+
+#. 在 MNIST 测试集上进行测试，通过 ``--model`` 指定权重路径：
+
+   .. code-block:: shell
+
+      python3 examples/deploy/fastapi/test.py --data /path/to/MNIST \
+      --model examples/deploy/fastapi/output/checkpoint.pkl 
+
+#. 使用单张图片进行推理预测，通过 ``--image`` 指定图片路径：
+
+   .. code-block:: shell
+
+      python3 examples/deploy/fastapi/inference.py --image /path/to/image \
+      --model examples/deploy/fastapi/output/checkpoint.pkl
+
+   如果未给定图片路径，则会默认使用这张图片：
+
+   .. figure:: ../../_static/images/handwrittern-digit.png
+      :height: 250
+
+   你将会看到输出预测这张图片的分类为数字 6.
+
+.. note:: 
+
+   到这一步，我们可以说是开发出了一个能够识别 “白底黑字手写数字” 的模型。
+   上面的单张图片的推理过程，即给定输入图片 :math:`\mathcal{I}`, 输出对分类的预测——
+   这可以作为服务部署到服务器设备上。
+
+使用 FastAPI 部署模型
+---------------------
+
+本小节我们将讨论部署（Deploying）的有关概念，主要侧重为服务器（Server）端部署，
+通过将模型部署到一台服务器上，客户端（Client）则将能够向服务器发送请求（Request）来完成交互。
+我们不会讨论过多有关 Client-Server 交互的概念，你可以在互联网上找到相当多介绍它们的材料。
+
+机器学习模型存在于 等待接收来自客户端提交的预测请求的 服务器中，推理逻辑与 ``inference.py`` 基本一致：
+
+.. code-block:: python
+
+   import megengine as mge
+   from model import LeNet
+
+   checkpoint_path = "output/checkpoint.pkl"
+   checkpoint = mge.load(checkpoint_path)
+   if "state_dict" in checkpoint:
+       state_dict = checkpoint["state_dict"]
+
+   model = LeNet()
+   model.load_state_dict(state_dict)
+
+   # Input data (request from the client)
+   # ...
+
+   pred = model(data)
+
+   # Return the result back to the client
+
+当模型被部署到服务器上时，输入的数据 `data` 将来自于从客户端发往服务器的请求，
+换而言之，想要让服务器进行正确的预测，客户端的请求中必须包含正确的输入信息；
+最终服务器需要将预测并且处理好的结果返回给客户端，以供客户端用作其他用途。我们将通过 
+FastAPI 来快速地搭建起服务器应用的原型。
+
+FastAPI 实例的创建
+~~~~~~~~~~~~~~~~~~
+
+创建 FastAPI 实例的步骤很简单：
+
+>>> app = FastAPI()
+
+接着我们需要创建用于推理服务的端点（Endpoints），一切准备就绪后，只需要运行：
+
+>>> uvicorn.run(app)
+
+这样你能够快速地搭建起一个异步网关接口（ASGI）实现，其中 FastAPI 负责提供 API, 
+``uvicorn`` 负责提供网关服务，只是目前它还不能够做任何事情。
+我们不需要理解背后的技术细节，就能够完成教程后面的步骤。
+接下来我们要做的事情是：1. 完成请求与返回逻辑； 2. 将模型推理的步骤加入相应流程。
+
+Endpoints 的创建
+~~~~~~~~~~~~~~~~
+
+在 FastAPI 中创建为实例 ``app`` 创建端点的方法很简单：
+
+.. code-block:: python
+   
+   @app.get("/")
+   def home():
+         return "The server is woking~ Now head over to http://localhost:8000/docs"
+
+当运行 ``uvicorn.run(app, host="127.0.0.1", port=8000)`` 时，
+将会在监听发送到本地 8000 端口 ``/`` 路径的所有 `get` 请求，
+并按照 ``home()`` 中的逻辑处理和返回信息，上面的例子中将返回文本信息。
+
+你完全可以为不同的机器学习模型创建多个端点（假定域名为 ``mymodel.com`` ）：
+
+* mymodel.com/handwrittern-digit-classification
+* mymodel.com/object-detection
+* mymodel.com/speech-to-context
+
+这样你就能够为能够访问到你服务器的多个客户端提供服务。
+本教程中将假设服务器为你本地的机器，你将通过创建一个异步的 ``prediction`` 
+函数来定义端点 ``/predict``, 并负责处理该端点的所有逻辑：
+
+.. code-block:: python
+
+   @app.post("/predict")
+   async def prediction(file: UploadFile = File(...)):
+       # Get data <-------- clients
+
+       # Do something here...
+       mdoel(processed_data)
+       # Do something here...
+
+       # Return ----------> clients
+
+所以我们要做的事情是，发送一张带有手写数字图片数据的请求，希望返回预测分类。
+
+.. admonition:: HTTP 请求的类型
+
+   客户端和服务器之间通过一种称为 HTTP 的协议相互通信。两个非常常见的行为是：
+
+   * ``GET`` -> 从服务器检索信息。
+   * ``POST`` -> 向服务器提供信息，用于响应。
+
+   与存放在服务器端点上机器学习模型的交互通常通过 ``POST`` 完成，
+   因为需要客户端需要向其提供一些信息以用于预测。
+   在上面的 ``prediction`` 代码中，需要提供 ``file``, 也即将文件作为请求中的参数。
+
+完整的 Server 实现
+~~~~~~~~~~~~~~~~~~
+
+请参考 :docs:`examples/deploy/fastapi/server.py` 中给出的代码，其中 ``prediction`` 实现如下：
+
+.. literalinclude:: ../../../examples/deploy/fastapi/server.py
+   :lines: 28-58
+
+参考实现的逻辑非常简单，对文件的拓展名和类型进行了检查，看是否是图片；
+接着以字节流的形式读入图片，转换成 ndarray 格式后借助 OpenCV 进行读入；
+后面的处理步骤就是我们比较熟悉的推理过程了；最终我们返回了一个字典，
+其中 ``likely_class`` 即模型预测的分类结果。
+
+.. seealso::
+
+   这不是唯一的实现方式，你可以查阅 FastAPI 等文档进行自己的实现。
+
+运行 ``server`` 脚本，访问 http://localhost:8000/ 即可看到服务器已经成功启动！
+
+.. code-block:: shell
+
+   python3 examples/deploy/fastapi/server.py
+
+使用 FastAPI 客户端快速验证
+---------------------------
+
+FastAPI 框架的另一个便捷之处在于，你可以通过访问 http://localhost:8000/docs
+来启动一个内置的客户端，以便模拟发送请求，用于快速进行功能和结果的验证。
+
+.. figure:: ../../_static/images/fastapi.png
+
+#. 点击 ``/predict`` 端点，将其中的内容展开；
+#. 点击 ``Try it out`` 按钮，在 ``file`` 一栏选择一张白底黑字的手写数字图片文件上传；
+#. 点击 ``Execute`` 发送 ``POST`` 请求，服务器将会给你返回对应的预测信息。
+
+这种方式有什么问题？
+--------------------
+
+前面提到，这种方式可以方便快捷地作为 Demo 进行验证和演示，但不是生产环境下的最佳实践。
+
+最主要的两点原因为： **1. 可移植性差；2. 性能不够好。**
+
+.. admonition:: 推理部署强调可移植性
+
+   我们希望训练好的模型能够在不同的平台和设备上运行，比如手机、汽车等等。
+   目前的这种推理方式依赖原生 Python 运行时，且无法摆脱 GIL
+   带来的影响，在性能受限的场景下难以发挥作用。
+   因此我们会希望 MegEngine 模型能够被序列化保存并加载到没有 Python 依赖项的进程中。
+
+.. admonition:: 推理部署强调极致性能优化
+
+   为了方便调试，MegEngine 默认使用动态图模式，在此模式下所有语句都是以解释的方式立即执行的；
+   实际上，MegEngine 支持切换到静态图模式，这种模式能够拿到更多的图信息，
+   在运行期间可以进行各种优化以提高性能。就好像编译执行的语言通常都会比解释执行的语言更快一样。
+
+   参考 :ref:`jit-guide` 页面，你能看到更多有关动态图和静态图的解释。
+
+在接下来的教程中，你会看到我们如何通过 MegEngine 的即时编译技术将动态图转换为静态图，
+并且序列化导出，使之能够部署到对性能和资源占用要求都比较高的环境中去，我们将接触到
+MegEngine Lite 来充分发挥 MegEngine 的多平台推理能力，同时兼顾高精度和高性能的要求。
+
+参考文献
+--------
+
+.. footbibliography::

--- a/source/getting-started/deploy/index.rst
+++ b/source/getting-started/deploy/index.rst
@@ -1,0 +1,97 @@
+.. _megengine-deploy:
+
+==========================
+MegEngine 模型推理部署教程
+==========================
+
+.. warning:: 这套教程正处于缓慢发布状态，你看到的非最终成品，欢迎参与讨论改进。
+
+.. admonition:: 适用人群 & 前置知识要求
+   :class: note
+
+   本套教程适合那些想要知道 “如何将深度学习模型部署到生产环境中” 的开发者：
+
+   * 也许你刚学习完 《 :ref:`deep-learning` 》，已经能够开发出一些简单的模型了，
+     但对如何将模型部署到不同的平台和设备十分好奇，想要尝试一些具体的实践，这套教程将带你入门；
+   * 如果你完全不关注模型开发的过程和细节，希望故事从已经拿到一个训练好的模型开始讲起。
+     不妨先试试看阅读用户指南中的 :ref:`deployment` 并进行实践，感到吃力的话再来阅读本系列教程。
+
+   你需要具备一定的 Python 开发经验，进阶主题中我们将会用到 C++ 与源码编译，以追求极致的性能。
+
+.. dropdown:: :fa:`eye,mr-1` 体验现实生活中的 MegEngine 推理服务（Face++）
+
+   推理服务通常部署在云端服务器（对外提供 gRPC/HTTP 接口请求）或是边缘计算设备（例如用户移动终端）上。
+   例如 `旷视 Face++ 人工智能开放平台 <https://www.faceplusplus.com.cn/>`_ ，
+   为开发者提供人脸识别、人像处理、人体识别、文字识别、图像识别等 AI 能力，里面使用的即 MegEngine 推理引擎。
+   开发者可以选择使用接入云端服务器上提供的 API 使用服务器上的模型推理，
+   也可以选择使用封装好的 SDK 服务，在各种设备上离线进行使用。
+
+   通过本系列教程的学习，你将能够基于 MegEngine 搭建起自己的推理服务或开发出推理
+   Demo 应用。
+
+
+内容安排与组织
+--------------
+
+这套 MegEngine 模型推理部署教程由多个章节组成：
+
+.. toctree::
+   :maxdepth: 1
+
+   fast-api
+
+在用户指南的 :ref:`deployment` 页面中，对常见情况进行了总结，并给出了最佳实践。
+而本套教程将从最原始的情况 —— 即使用与模型训练完全一致环境的，向你演示模型部署的最简概念与形式。
+接着与你一同去思考在生产情景下需要考虑的成本和效率问题，从而接触到不同的推理部署情景，并进行实战。
+
+在此之前，如果你还不熟悉 MLOps 的整个流程，建议阅读下一小节的有关介绍：
+
+真实世界的机器学习系统
+----------------------
+
+.. admonition:: ML Ops: Machine Learning Operations
+
+   在 Google 发布的《Hidden Technical Debt in Machine Learning Systems :footcite:p:`sculley2015hidden` 》
+   论文中指出，机器学习的代码在整个机器学习项目中可能只是很小的一块比例（下图黑色块部分） ——
+
+   .. figure:: ../../_static/images/real-world-ml-system.png
+
+      Only a small fraction of real-world ML systems is composed of the ML code, as shown
+      by the small black box in the middle. The required surrounding infrastructure is vast and complex.
+
+   如果你已经成功地开发出一个机器学习模型 —— 给定输入 :math:`\mathcal{X}`, 能够如期预测输出 :math:`\mathcal{Y}`.
+   我们将这一步称为是模型开发中的概念验证（Proof of concept, POC）.
+   但想要将训练完成的模型落地成生产环境中可用的项目，我们还需要经历其它的一些步骤。
+   实际上，一个完整的机器学习项目的生命周期将类似于：
+
+   .. mermaid::
+      :align: center
+      :caption: MLOps 基本环节：选定范围、数据获取与处理、模型开发、部署应用
+
+      flowchart LR
+          Scoping --> Data --> Modeling --> Deployment
+
+   #. 选定范围：确定项目类型、关键的几个指标（精度、延迟、带宽等等）、预估资源量与排期...
+   #. 数据：定义数据形式，建立相关的 Baseline, 采集和标注数据等等相关处理...
+   #. 模型开发：设计出合适的模型结构、调整超参数、在给定数据集上训练并达标...
+   #. 部署应用：在生产环境中部署模型进行推理，对指标进行监控，进行长期的维护...
+
+   通常整个流程不是线性的，而是会在各个环节之间根据结果循环进行调整，以整体达到更好的效果。
+
+.. seealso::
+
+   .. figure:: ../../_static/images/ml-iteration.png
+
+      模型部署与模型开发的过程类似，需要在流程中不断迭代调优。
+
+   Deeplearning.ai 团队的 《 `Machine Learning Engineering for Production 
+   <https://www.deeplearning.ai/program/machine-learning-engineering-for-production-mlops/>`_ 》
+   课程对 MLOps 有着更加详细的解释和案例分析，本系列教程将基于 MegEngine, 
+   专注向你展示部署（Deployment）的基本流程。
+
+参考文献
+--------
+
+.. footbibliography::
+
+

--- a/source/getting-started/index.rst
+++ b/source/getting-started/index.rst
@@ -8,6 +8,7 @@
 
    quick-start
    beginner/intro
+   deploy/index
 
 我们为带有不同学习需求的用户提供了对应的新手入门教程，共同成长。
 

--- a/source/getting-started/quick-start.rst
+++ b/source/getting-started/quick-start.rst
@@ -14,7 +14,8 @@ MegEngine 快速上手
 
 .. seealso::
 
-   本教程的对应源码： :docs:`examples/quick-start.py`
+   * 本教程展示模型开发基本流程，对应源码： :docs:`examples/quick-start.py`
+   * 只关注模型部署流程的用户可以阅读 :ref:`megengine-deploy` 🚀🚀🚀
 
 概览
 ----
@@ -155,8 +156,10 @@ MegEngine 快速上手
 训练：优化模型参数
 ------------------
 
-得到前向计算输出后，为了优化模型参数，我们还需借助
-:class:`~.GradManager` 和 :class:`~.Optimizer` 进行反向传播：
+得到前向计算输出后，为了优化模型参数，我们还需要：
+
+* 使用 :class:`~.GradManager` 对参数梯度进行管理；
+* 使用 :class:`~.Optimizer` 进行反向传播和参数更新（以 :class:`~.SGD` 为例）。
 
 .. code-block:: python
 
@@ -174,7 +177,7 @@ MegEngine 快速上手
 接下来训练我们的模型：将训练数据集分批地喂入模型，前向计算得到预测值，
 根据设计好的损失函数（本教程中使用交叉熵 :func:`~.cross_entropy` ）计算。
 接着调用 :meth:`.GradManager.backward` 方法来自动进行反向计算并记录梯度信息，
-然后根据这些梯度信息来更新模型中的参数。
+然后根据这些梯度信息来更新模型中的参数，即调用 :meth:`.Optimizer.step` 方法。
 
 .. code-block:: python
 
@@ -196,7 +199,7 @@ MegEngine 快速上手
 
        print(f"Epoch: {epoch}, loss: {total_loss/len(train_dataset)}")
 
-.. note:: 记得将数据转为 MegEngine :class:`~.Tensor` 格式，参考 :ref:`tensor-guide` 。
+.. warning:: 记得将数据转为 MegEngine :class:`~.Tensor` 格式，参考 :ref:`tensor-guide` 。
 
 .. seealso::
 
@@ -224,8 +227,10 @@ MegEngine 快速上手
 
 通常会得到一个在测试集上接近甚至超过 99% 预测正确率的模型。
 
-（可选）用图片进行验证
-~~~~~~~~~~~~~~~~~~~~~~
+注：通常的训练流程中应当使用验证集，每训练一段时间就及时验证，这里简化了这一步。
+
+推理：用单张图片验证
+--------------------
 
 我们也可以选择使用自己的手写数字图片来验证模型效果（你可以选择使用自己的图片）：
 
@@ -259,6 +264,11 @@ MegEngine 快速上手
 
 可以发现，我们训练出的 LeNet 模型成功地将手写该数字图片的标签类别预测为 6 ！
 
+.. seealso::
+
+   这里展示的是最简单的模型推理情景，MegEngine 是一个训练推理一体化的框架，
+   能将训练好的模型导出，在 C++ 环境下高效地进行推理部署，可参考 :ref:`deployment` 中的介绍。
+
 接下来做些什么？
 ----------------
 
@@ -277,7 +287,8 @@ MegEngine 快速上手
    同时，由于这仅仅是一份快速上手教程，许多模型开发的进阶特性没有进行介绍，例如
    :ref:`distributed-guide` / :ref:`quantization-guide` ... 等专题，可以在 :ref:`user-guide` 中找到。
    值得一提的是，MegEngine 不仅仅是一个深度学习训练框架，同时也支持便捷高效的模型推理部署。
-   关于模型推理部署的内容，可以参考 :ref:`deployment` 页面的介绍。
+   关于模型推理部署的内容，可以参考 :ref:`deployment` 页面的介绍与
+   《 :ref:`megengine-deploy` 》。
 
 .. admonition:: 任何人都可以成为 MegEngine 教程的贡献者
    :class: note

--- a/source/refs.bib
+++ b/source/refs.bib
@@ -119,3 +119,11 @@ terms= {}
   year={2021},
   url={https://openreview.net/forum?id=Vfs_2RnOD0H}
 }
+
+@article{sculley2015hidden,
+  title={Hidden technical debt in machine learning systems},
+  author={Sculley, David and Holt, Gary and Golovin, Daniel and Davydov, Eugene and Phillips, Todd and Ebner, Dietmar and Chaudhary, Vinay and Young, Michael and Crespo, Jean-Francois and Dennison, Dan},
+  journal={Advances in neural information processing systems},
+  volume={28},
+  year={2015}
+}


### PR DESCRIPTION
- [x] 与 [快速上手](https://megengine.org.cn/doc/stable/zh/getting-started/quick-start.html) 对应的 FastAPI Code.
- [x] 更新对推理部署的整体介绍，以 FastAPI 的最简 demo 为例子，引出在更多需求情景下单推理部署方案
- [x] 更新快速上手页面内容和代码，需要提到模型保持、加载和推理，整个流程更加完备