### PR TITLE
feat: add meta information for HTML pages

### DIFF
--- a/source/_templates/indexcontent.html
+++ b/source/_templates/indexcontent.html
@@ -1,4 +1,11 @@
 {% extends "layout.html" %}
+{%- block extrahead -%}
+<meta content="天元 MegEngine 官方文档" lang="zh-Hans" name="description" xml:lang="zh-Hans" />
+<meta content="MegEngine official documentation" lang="en" name="description" xml:lang="en" />
+<meta content="天元, 深度学习, 深度学习框架, 文档, 教程, 参考, 开发, 旷视科技" lang="zh-Hans" name="keywords" xml:lang="zh-Hans" />
+<meta content="MegEngine, deep learning, deep learning framework, documentation, tutorial, reference, development, megvii" lang="en" name="keywords" xml:lang="en" />
+{%- endblock -%}
+
 {%- block htmltitle -%}
 <title>{{ shorttitle }}</title>
 {%- endblock -%}

--- a/source/development/index.rst
+++ b/source/development/index.rst
@@ -3,6 +3,11 @@
 ==========
 开发者指南
 ==========
+.. meta::
+   :description lang=zh-Hans: 天元 MegEngine 框架开发者的参考说明书。
+   :description lang=en: MegEngine developer reference manual.
+   :keywords lang=zh-Hans: 天元, 深度学习, 框架, 开发者, 参考, 手册, 说明书
+   :keywords lang=en: MegEngine, deep learning, framework, developer, reference, manual
 
 .. toctree::
    :maxdepth: 1

--- a/source/getting-started/index.rst
+++ b/source/getting-started/index.rst
@@ -3,6 +3,12 @@
 ========
 新手入门
 ========
+.. meta::
+   :description lang=zh-Hans: 天元 MegEngine 入门教程，适合不同水平、阶段的用户。
+   :description lang=en: MegEngine tutorials for users of all levels.
+   :keywords lang=zh-Hans: 天元, 教程, 课程, 新手入门, 快速上手, 学习, 深度学习
+   :keywords lang=en: MegEngine, deep learning, tutorial, beginner, quick start, learning, crash course
+
 .. toctree::
    :hidden:
 
@@ -45,4 +51,3 @@ MegEngine 可以使用 Python 包管理器 ``pip`` 直接进行安装：
    ^^^^^^^^^^^^^^^^^^^^^^
    如果你想要通过实践 MegEngine 的使用来加深对基础知识的理解，
    我们为你准备了一系列 :ref:`deep-learning` ，希望能有所帮助！
- 

--- a/source/reference/index.rst
+++ b/source/reference/index.rst
@@ -3,6 +3,12 @@
 ========
 API 参考
 ========
+.. meta::
+   :description lang=zh-Hans: 天元 MegEngine API 定义与使用介绍，提供权威参考信息。
+   :description lang=en: MegEngine API manual and official reference.
+   :keywords lang=zh-Hans: 天元, 深度学习, 接口, 规格, 定义, 查询, 引用, 参考, 用例
+   :keywords lang=en: MegEngine, deep learning, interface, specification, define, reference, example
+
 :对应版本: |version|
 :更新时间: |today|
 

--- a/source/user-guide/index.rst
+++ b/source/user-guide/index.rst
@@ -3,6 +3,12 @@
 ========
 用户指南
 ========
+.. meta::
+   :description lang=zh-Hans: 天元 MegEngine 用户指南，能够引导用户在不同需求下完成相应的目标。
+   :description lang=en: MegEngine guides that help users accomplish the corresponding goals in different situations.
+   :keywords lang=zh-Hans: 天元, 深度学习, 指南, 用户指南, 使用手册, 案例, 示范, 如何完成
+   :keywords lang=en: MegEngine, deep learning, guide, user guide, how-to, example, step-by-step
+
 .. toctree::
    :hidden:
    :maxdepth: 1


### PR DESCRIPTION
This is an example commit. @jiaochenlu 举一反三的时间到了。

![image](https://user-images.githubusercontent.com/21091736/160591853-1ef08446-6278-457f-87c7-b1015a4c55df.png)

---------------------------------
注意事项：
- Keyword 中间用英文逗号 + 空格隔开（哪怕是中文内容）
- 务必带上 `lang` 标签，中文用 `zh-Hans`, 英文用 `en`

无法通过 Review 的案例

1. 没有严格区分中英双语的 `lang` 属性；
2. Keyword 与页面内容无关；
3. Description 简单拷贝原文开头内容，没起到全文描述的效果。

Refs:

- https://moz.com/learn/seo/meta-description
- https://blog.alexa.com/seo-meta-descriptions/