### PR TITLE
Check whether the exist sphinx-sitemap ext works or not

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ sphinx-tabs
 sphinx-togglebutton
 sphinx-panels
 sphinx-remove-toctrees
+sphinx-sitemap
 jieba
 ipython
 recommonmark

--- a/source/conf.py
+++ b/source/conf.py
@@ -85,6 +85,7 @@ extensions = [
     "sphinx_panels",
     "sphinx_tabs.tabs",
     "sphinx_remove_toctrees",
+    "sphinx_sitemap",
 ]
 
 source_suffix = {
@@ -188,6 +189,12 @@ remove_from_toctrees = [
     "reference/api/*",
     "development/meps/*",
 ]
+
+# Settign for sphinx_sitemap
+sitemap_filename = "sitemap.xml"
+sitemap_locales = ["en", "zh"]
+html_baseurl = "https://www.megengine.org.cn/doc/"
+sitemap_url_scheme = "{version}{lang}{link}"
 
 # -- Options for HTML output -------------------------------------------------
 html_logo = "logo.png"


### PR DESCRIPTION
## Known issues

- The extension load the locals setting from Sphinx's [language](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language) configuration, which causes that the string `zh_CN` (not `zh` we use actually) will be placed in the final URL path.
- The extension is not safe for parallel reading so it will always make the CI building check failed (any warning is not allowed now), could not be supressed directly.

## Solution might works

Write a plugin specifically for our documentation.

https://github.com/jdillard/sphinx-sitemap/pull/29 Might be helpful.