### PR TITLE
fix(deps): lock sphinxcontrib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 sphinx==4.3.2
 sphinx-autobuild
 sphinx-intl
-sphinxcontrib-mermaid
-sphinxcontrib-bibtex
+sphinxcontrib-mermaid==0.8.1
+sphinxcontrib-bibtex==2.4.2
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-tabs


### PR DESCRIPTION
新版的sphinxcontrib-mermaid使用了docutils里的一个findall方法，这个方法只在docutils版本大于0.18.1时提供。然而项目目前的依赖关系限制了docutils版本必须小于0.18