### PR TITLE
fix(sphinx-theme): fix sphinx theme version for ci

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7.17
+          python-version: 3.9.18
 
       - name: Cache Python packages
         id: cache-python
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7.17
+          python-version: 3.9.18
 
       - name: Get cached Python packages
         id: cache-python

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7.17
+          python-version: 3.9.18
 
       - name: Cache Python packages
         id: cache-python
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7.17
+          python-version: 3.9.18
 
       - name: Get cached Python packages
         id: cache-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Cache key for GitHub Actions: v1.13.2
-sphinx==4.3.2
+sphinx==5.0.2
 sphinx-autobuild
 sphinx-intl
 sphinxcontrib-mermaid==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ sphinx-tabs
 sphinx-togglebutton
 sphinx-panels
 sphinx-remove-toctrees
+pydata-sphinx-theme==0.14.4
 jieba
 ipython
 recommonmark
@@ -17,5 +18,3 @@ nbsphinx
 beautifulsoup4
 breathe
 
-# Third party
-third_party/pydata-sphinx-theme


### PR DESCRIPTION
gitlab ci失败，排查到是requirement中最后一行在安装sphinx theme的版本时失败，代码中已经有安装pydata-sphinx-theme==0.14.4的逻辑了 所以可以删掉最后一行